### PR TITLE
New todo on an empty line + Allowed filetypes

### DIFF
--- a/itodo.py
+++ b/itodo.py
@@ -4,7 +4,11 @@ from datetime import datetime
 class ItodoBase(sublime_plugin.TextCommand):
   def run(self, edit):
     filename = self.view.file_name()
-    if filename is None or not filename.endswith('.todo'):
+    # list of allowed filetypes
+    # (added this because some people, like me, tend to use .txt files because they're more universal)
+    # (this means that i have to manually set syntax for such file, but it's no sweat ;)
+    allowed_filetypes = ('.todo', '.txt')
+    if filename is None or not filename.endswith(allowed_filetypes):
       return False  
     self.runCommand(edit)
 


### PR DESCRIPTION
I installed your plugin but noticed that when I create new todo with CMD+i, and the cursor is on an empty line, then I'm getting unwanted newline added. This pull request handles with this case.

This is useful if you want to "divide" your todos with an empty line or just simply want to add a new todo without having to move cursor up one line.
## 

I tend to use .txt files for todos just because they can be quickly opened using _any_ editor or application, nothing major but may add a bit more flexibility for those who simply prefer .txt format.

Simple as that ;)

Thanks for a great plugin, I'm going to start using it :)
